### PR TITLE
When the page name contains and amperstand (&), it breaks the hole page

### DIFF
--- a/data-sources/data.plh_page.php
+++ b/data-sources/data.plh_page.php
@@ -49,7 +49,7 @@ Class datasourceplh_page extends Datasource{
     	foreach ($languageCodes as $key => $language) {
     		$itemXML = new XMLElement(
 					'item', 
-    				$pages[$i]['page_lhandles_t_'.$languageCodesH[$key] ],
+    				htmlspecialchars ( $pages[$i]['page_lhandles_t_'.$languageCodesH[$key] ] , ENT_NOQUOTES ), // espace &
     				array(
 						'lang' => $language,
 						'handle' => $pages[$i][ 'page_lhandles_h_'.$languageCodesH[$key] ]


### PR DESCRIPTION
added a call to htmlspecialchars in order to escape special chars in the page name
