### PR TITLE
Make sure to add parent IS NULL in the where clause to avoid confusion with sub pages

### DIFF
--- a/lib/class.pagelhandles.php
+++ b/lib/class.pagelhandles.php
@@ -157,7 +157,8 @@
 					} else { 
 						// specify that parent must be null to avoid
 						// confusion between /en/calendar vs. /en/some-folder/calendar
-						// /en/calendar -> calendard page must not have a parent
+						// ex.: /en/calendar -> calendar page must not have a parent
+						// 		/en/some-folder/calendar -> calendar page must have some-folder as parent
 						$query .= ' AND `parent` IS NULL';
 					}
 					$query .= ' LIMIT 1';


### PR DESCRIPTION
Make sure to add parent IS NULL in the where clause to avoid confusion with sub pages

Sorry! Add 2 lines to the pull request done yesturday
