### PR TITLE
Save config on update

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -102,6 +102,7 @@
 
 			if( version_compare($previous_version, '2.4', '<') ){
 				Symphony::Configuration()->set('op_mode', $this->op_modes[0]['handle'], PLH_GROUP);
+				Symphony::Configuration()->write();
 			}
 
 			return true;


### PR DESCRIPTION
The only missing call was `Symphony::Configuration()->write();` since the set was already there in the update method. Your install was already fine.

You here you go, another pull request for one line of code!
