### PR TITLE
Update for Symphony 4.x

### DIFF
--- a/extension.driver.php
+++ b/extension.driver.php
@@ -251,9 +251,9 @@
 			/*  Tabs  */
 			/*------------------------------------------------------------------------------------------------*/
 
-			$ul = new XMLElement('ul', null, array('class' => 'tabs'));
+			$ul = new XMLElement('ul', null, array('class' => 'tabs inverted-margin'));
 			foreach( $langs as $lc ){
-				$li = new XMLElement('li', $all_langs[$lc], array('class' => $lc));
+				$li = new XMLElement('li', $lc, array('class' => $lc));
 				$lc === $main_lang ? $ul->prependChild($li) : $ul->appendChild($li);
 			}
 

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -369,7 +369,7 @@
 		 */
 		private function _appendConsolidate(XMLElement &$wrapper){
 			$label = Widget::Label(__('Consolidate entry data'));
-			$label->appendChild(Widget::Input('settings['.PLH_GROUP.'][consolidate]', 'yes', 'checkbox', array('checked' => 'checked')));
+			$label->prependChild(Widget::Input('settings['.PLH_GROUP.'][consolidate]', 'yes', 'checkbox', array('checked' => 'checked')));
 			$wrapper->appendChild($label);
 			$wrapper->appendChild(new XMLElement('p', __('Check this field if you want to consolidate database by <b>keeping</b> entry values of removed/old Language Driver language codes. Entry values of current language codes will not be affected.'), array('class' => 'help')));
 		}

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -24,7 +24,7 @@
 		<dependency version="2.5">https://github.com/vlad-ghita/frontend_localisation</dependency>
 	</dependencies>
 	<releases>
-		<release version="3.0.0" date="TBA" min="4.0.0" max="4.x.x"><![CDATA[
+		<release version="3.0.0" date="TBA" min="4.0.0" max="4.x.x" php-min="5.6.x" php-max="7.x.x"><![CDATA[
 			* Update for Symphony 4.x
 		]]></release>
 		<release version="2.10.1" date="2017-04-12" min="2.3" max="2.x.x"><![CDATA[

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -24,6 +24,9 @@
 		<dependency version="2.5">https://github.com/vlad-ghita/frontend_localisation</dependency>
 	</dependencies>
 	<releases>
+		<release version="3.0.0" date="TBA" min="4.0.0" max="4.x.x"><![CDATA[
+			* Update for Symphony 4.x
+		]]></release>
 		<release version="2.10.1" date="2017-04-12" min="2.3" max="2.x.x"><![CDATA[
 			* Fix for PHP 7 support
 		]]></release>


### PR DESCRIPTION
Update release version.
Put label text after checkbox input to fit in with new Symphony 4.x layout.
cc @nitriques